### PR TITLE
Fixed compilation for Windows

### DIFF
--- a/scripts/compile-windows.bat
+++ b/scripts/compile-windows.bat
@@ -12,8 +12,9 @@ if exist ..\build\ (
   cmake --build . --config Release
 ) else (
   echo Compile-Windows: Build folder not found.
+  cd ..
   mkdir build
-  cd ../build
+  cd ./build
   conan install ..
   cmake -G "Visual Studio 16 2019" ../src 
   cmake --build . --config Release


### PR DESCRIPTION
## Name 
Fixed compilation for Windows

## Description
When build folder didn't exist the compilation script for Windows wasn't working good.

## Changelog
- Changed creating of build folder in compile-windows

## Reviewer
@mateuszpolec 