### PR TITLE
Changed copying dlls into bin folder

### DIFF
--- a/conanfile.txt
+++ b/conanfile.txt
@@ -6,10 +6,9 @@ boost/1.77.0
 cmake
 
 [options]
-sfml:shared=True
 boost:shared=True
 
 [imports]
-bin, *.dll -> ./App/bin
+bin, *.dll -> ./App/lib
 
 # TODO: Add the same for Linux in the future.

--- a/src/App/CMakeLists.txt
+++ b/src/App/CMakeLists.txt
@@ -8,6 +8,5 @@ add_executable(${PROJECT_NAME} main.cpp)
 
 # Include all needed libraries.
 target_link_libraries(${PROJECT_NAME} 
-  onyx_engine::framework
   onyx_engine::game
 )


### PR DESCRIPTION
## Name 
Changed copying dlls into bin folder

## Description
Boost dlls was copied into bin folder. This issue was creating a lot of dlls in this folder and was problematic to find proper .exe folder.

## Changelog
- Changed way of copying dlls into build/App/ folder
- Removed include of Framework into main app

## Reviewer
@mateuszpolec 